### PR TITLE
DEV-27422 Use cancelled in consistance with the API

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,7 +33,7 @@ export enum ErrorType {
   SSO = 'sso',
   NotFound = 'not_found',
   SigninTimedOut = 'interactiveSignInTimedOut',
-  CheckCanceled = 'checkCanceled',
+  CheckCancelled = 'checkCancelled',
   CheckFailed = 'checkFailed',
   CustomFieldsIncorrect = 'customFieldsIncorrect',
   Validation = 'validation',
@@ -153,10 +153,10 @@ export function wrapFetchError(httpRequest: HttpRequest, error: Error): Promise<
   });
 }
 
-export class CheckCanceledByClientError extends AcrolinxError {
+export class CheckCancelledByClientError extends AcrolinxError {
   constructor(props: AcrolinxErrorProps) {
     super(props);
-    setCorrectErrorPrototype(this, CheckCanceledByClientError);
+    setCorrectErrorPrototype(this, CheckCancelledByClientError);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
 } from './common-types';
 import {AddToDictionaryRequest, AddToDictionaryResponse, DictionaryCapabilities} from './dictionary';
 import {DocumentDescriptor, DocumentId, sanitizeDocumentDescriptor} from './document-descriptor';
-import {AcrolinxError, CheckCanceledByClientError, ErrorType, wrapFetchError} from './errors';
+import {AcrolinxError, CheckCancelledByClientError, ErrorType, wrapFetchError} from './errors';
 import {AnalysisRequest, ExtractionResult} from './extraction';
 import {PlatformFeatures, PlatformFeaturesResponse} from './features';
 import {
@@ -93,7 +93,7 @@ export {
   AcrolinxError,
   AccessToken,
   CheckingCapabilities,
-  CheckCanceledByClientError,
+  CheckCancelledByClientError,
   CancelCheckResponse,
   GuidanceProfile,
   ErrorType,
@@ -456,8 +456,8 @@ export class AcrolinxEndpoint {
     asyncStartedProcessPromise: Promise<AsyncStartedProcess>,
     opts: CancelablePollLoopOptions = {}
   ): CancelablePromiseWrapper<Result> {
-    let canceledByClient = false;
-    let requestedCanceledOnServer = false;
+    let cancelledByClient = false;
+    let requestedCancelledOnServer = false;
     let runningCheck: AsyncStartedProcess | undefined;
 
     let cancelPromiseReject: (e: Error) => void;
@@ -466,23 +466,23 @@ export class AcrolinxEndpoint {
     });
 
     function cancel() {
-      canceledByClient = true;
-      cancelPromiseReject(createCheckCanceledByClientError());
+      cancelledByClient = true;
+      cancelPromiseReject(createCheckCancelledByClientError());
       cancelOnServerIfPossibleAndStillNeeded();
     }
 
     const handlePotentialCancellation = () => {
-      if (canceledByClient) {
+      if (cancelledByClient) {
         cancelOnServerIfPossibleAndStillNeeded();
         // We don't want to poll forever if the canceling does not work on the server.
         // To be consistent we throw the same exception, that the server would throw while polling.
-        throw createCheckCanceledByClientError();
+        throw createCheckCancelledByClientError();
       }
     };
 
     const cancelOnServerIfPossibleAndStillNeeded = () => {
-      if (!requestedCanceledOnServer && runningCheck) {
-        requestedCanceledOnServer = true;
+      if (!requestedCancelledOnServer && runningCheck) {
+        requestedCancelledOnServer = true;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.cancelAsyncStartedProcess(accessToken, runningCheck, opts);
       }
@@ -636,11 +636,11 @@ function getSigninRequestHeaders(options: SigninOptions = {}): StringMap {
   }
 }
 
-function createCheckCanceledByClientError() {
-  return new CheckCanceledByClientError({
-    detail: 'The check was canceled. No result is available.',
-    type: ErrorType.CheckCanceled,
-    title: 'Check canceled',
+function createCheckCancelledByClientError() {
+  return new CheckCancelledByClientError({
+    detail: 'The check was cancelled. No result is available.',
+    type: ErrorType.CheckCancelled,
+    title: 'Check cancelled',
     status: 400
   });
 }

--- a/test/integration-server/acrolinx-endpoint.test.ts
+++ b/test/integration-server/acrolinx-endpoint.test.ts
@@ -21,7 +21,7 @@ import * as _ from 'lodash';
 import {
   AnalysisType,
   AppAccessTokenValidationResult,
-  CheckCanceledByClientError,
+  CheckCancelledByClientError,
   CheckRequest,
   CheckResult,
   CustomFieldType,
@@ -367,7 +367,7 @@ describe('e2e - AcrolinxEndpoint', () => {
         // According to Heiko, cancelling may need some time. (See also DEV-17377)
         await waitMs(1000);
 
-        await expectFailingPromise(api.pollForCheckResult(ACROLINX_API_TOKEN, check), ErrorType.CheckCanceled);
+        await expectFailingPromise(api.pollForCheckResult(ACROLINX_API_TOKEN, check), ErrorType.CheckCancelled);
       });
 
       it('cancel needs correct auth token', async () => {
@@ -444,13 +444,13 @@ describe('e2e - AcrolinxEndpoint', () => {
       });
 
 
-      it('can be canceled', async () => {
+      it('can be cancelled', async () => {
         const currentCheck = api.checkAndGetResult(ACROLINX_API_TOKEN, await createDummyCheckRequest());
 
         currentCheck.cancel();
 
-        const error = await expectFailingPromise<AcrolinxError>(currentCheck.promise, ErrorType.CheckCanceled);
-        expect(error).toBeInstanceOf(CheckCanceledByClientError);
+        const error = await expectFailingPromise<AcrolinxError>(currentCheck.promise, ErrorType.CheckCancelled);
+        expect(error).toBeInstanceOf(CheckCancelledByClientError);
       });
     });
 

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CheckCanceledByClientError, ErrorType} from '../../src/errors';
+import {CheckCancelledByClientError, ErrorType} from '../../src/errors';
 import {AcrolinxEndpoint} from '../../src/index';
 import {mockAcrolinxServer, mockBrokenJsonServer, restoreOriginalFetch} from '../test-utils/mock-server';
 import {DUMMY_ENDPOINT_PROPS, DUMMY_SERVER_URL} from './common';
@@ -59,14 +59,14 @@ describe('errors', () => {
 
   describe('custom errors and instanceof', () => {
     // Needed because of https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    it('CheckCanceledByClientError should support instanceof', () => {
-      const error = new CheckCanceledByClientError({
-        detail: 'The check was canceled. No result is available.',
-        type: ErrorType.CheckCanceled,
-        title: 'Check canceled',
+    it('CheckCancelledByClientError should support instanceof', () => {
+      const error = new CheckCancelledByClientError({
+        detail: 'The check was cancelled. No result is available.',
+        type: ErrorType.CheckCancelled,
+        title: 'Check cancelled',
         status: 400
       });
-      expect(error).toBeInstanceOf(CheckCanceledByClientError);
+      expect(error).toBeInstanceOf(CheckCancelledByClientError);
     });
   });
 });


### PR DESCRIPTION
I have changed the word canceled to cancelled in line with the Platform API. 