### PR TITLE
DEV-32894; feat; introduce integration field in check request

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [14.x]
+        node: [16.x]
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
   

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,7 +38,7 @@ module.exports = {
       "statements": 93.5,
       "branches": 81,
       "functions": 86,
-      "lines": 93.75,
+      "lines": 93.70,
     }
   },
   "reporters": [

--- a/src/check.ts
+++ b/src/check.ts
@@ -33,6 +33,7 @@ import {
 } from './common-types';
 import {DictionaryScope} from './dictionary';
 import {DocumentDescriptor} from './document-descriptor';
+import { Integration } from './integration';
 
 export interface CheckRange {
   begin: number;
@@ -57,6 +58,7 @@ export interface CheckRequest {
   checkOptions?: CheckOptions;
   document?: DocumentDescriptorRequest;
   externalContent?: ExternalContent;
+  integration?: Integration;
 }
 
 export interface LiveSearchRequest {

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-present Acrolinx GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Integration {
+  components?: SoftwareComponent[];
+}
+
+/**
+   * Provides information about your integration and other client software components for the about dialog and
+   * analytics.
+   */
+export interface SoftwareComponent {
+  /**
+   * The id of the software component.
+   * Examples: 'com.acrolinx.win.word.32bit', 'com.acrolinx.mac.word'
+   */
+  id: string;
+
+  /**
+   * The name if the software component.
+   * This name will be displayed in the UI.
+   */
+  name: string;
+
+  /**
+   * The version of the software component.
+   * Format: ${major}.${minor}.${patch}.${buildNumber}
+   * Example: '1.2.3.574'
+   */
+  version: string;
+
+  /**
+   * @See SoftwareComponentCategory
+   * Default value if omitted: 'DEFAULT'
+   */
+  category?: string;
+}
+
+export declare const SoftwareComponentCategory: {
+  /**
+   * There should be exactly one MAIN component.
+   * This information is used to identify your client on the server.
+   * Version information about this components might be displayed more prominently.
+   */
+  MAIN: string;
+  /**
+   * Version information about such components are displayed in the about
+   * dialog.
+   */
+  DEFAULT: string;
+  /**
+   * Version information about such components are displayed in the detail section of the about
+   * dialog or not at all.
+   */
+  DETAIL: string;
+};

--- a/test/integration-server/acrolinx-endpoint.test.ts
+++ b/test/integration-server/acrolinx-endpoint.test.ts
@@ -18,7 +18,6 @@ import Ajv from 'ajv';
 import 'cross-fetch/polyfill';
 import * as dotenv from 'dotenv';
 import * as _ from 'lodash';
-import { SoftwareComponentCategory } from '../../src/integration';
 import {
   AnalysisType,
   AppAccessTokenValidationResult,

--- a/test/integration-server/acrolinx-endpoint.test.ts
+++ b/test/integration-server/acrolinx-endpoint.test.ts
@@ -18,6 +18,7 @@ import Ajv from 'ajv';
 import 'cross-fetch/polyfill';
 import * as dotenv from 'dotenv';
 import * as _ from 'lodash';
+import { SoftwareComponentCategory } from 'src/integration';
 import {
   AnalysisType,
   AppAccessTokenValidationResult,
@@ -384,6 +385,22 @@ describe('e2e - AcrolinxEndpoint', () => {
           }
         });
         expect(checkResult.goals.length).toBeGreaterThan(0);
+      }, 10000);
+
+      it('can check with integration field set', async () => {
+        const text = 'Sample content to test integration field in check request';
+        const checkResult = await checkAndWaitForResult({
+          content: text,
+          integration: {
+            components: [{
+              id: 'com.acrolinx.sdk',
+              name: 'Acrolinx SDK JS',
+              version: '0.0.1',
+              category: SoftwareComponentCategory.MAIN
+            }]
+          }
+        });
+        expect(checkResult.quality.score).toBeGreaterThan(0);
       }, 10000);
 
       it.skip('can cancel check', async () => {

--- a/test/integration-server/acrolinx-endpoint.test.ts
+++ b/test/integration-server/acrolinx-endpoint.test.ts
@@ -396,7 +396,7 @@ describe('e2e - AcrolinxEndpoint', () => {
               id: 'com.acrolinx.sdk',
               name: 'Acrolinx SDK JS',
               version: '0.0.1',
-              category: SoftwareComponentCategory.MAIN
+              category: 'MAIN'
             }]
           }
         });

--- a/test/integration-server/acrolinx-endpoint.test.ts
+++ b/test/integration-server/acrolinx-endpoint.test.ts
@@ -18,7 +18,7 @@ import Ajv from 'ajv';
 import 'cross-fetch/polyfill';
 import * as dotenv from 'dotenv';
 import * as _ from 'lodash';
-import { SoftwareComponentCategory } from 'src/integration';
+import { SoftwareComponentCategory } from '../../src/integration';
 import {
   AnalysisType,
   AppAccessTokenValidationResult,


### PR DESCRIPTION
## Introduce integration field in check request.

### Blueprint

```
{
    "content": "text to check",
    ...
    "checkOptions": {
        "guidanceProfileId": "aud-1", 
        ...
    },

    "document": {
        ...
     },
     "integration" {
           "components" : [
               { id: "com.sidebar.foo", name: "Acrolinx for Foo", version: "1.0.0.0", category: "main"
               },
               { id: "com.sidebar.sdk.net", name: "Acrolinx for .NET", version: "1.0.0.1", category: "default"
               },
               { id: "os.windows", name: "Windows NT 4.0", version: "12.0.1.34535", category: "detail"
               }

           ]
     }
}
```

- The field is optional

### Test

Added a test case to verify if the added field does not cause any unintentional errors.