### PR TITLE
DEV-33400; chore: add permission for pages publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,10 @@ jobs:
       GITHUB_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
       ACROLINX_DEV_SIGNATURE: ${{ secrets.ACROLINX_DEV_SIGNATURE}}
 
+    # Write permission for "contents" required for gh-pages deployment action
+    permissions:
+     contents: write
+
     # TODO add timeout
     # TODO Provide Node & npm bin/ folder to PATH
     steps:
@@ -79,7 +83,7 @@ jobs:
       
       - name: Publish GitHub Pages 🚀
         if: steps.publish.outputs.type != 'none'
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@4.4.1
         with:
           branch: gh-pages
           folder: docs/pluginDoc


### PR DESCRIPTION
https://github.com/JamesIves/github-pages-deploy-action#getting-started-airplane

Warning If you do not supply the action with an access token or an SSH key, you must access your repositories settings and provide Read and Write Permissions to the provided GITHUB_TOKEN, otherwise you'll potentially run into permission issues. Alternatively you can set the following in your workflow file to grant the action the permissions it needs.

```
permissions:
  contents: write
```