### PR TITLE
feat: add provision for Authorization header

### DIFF
--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,3 +19,4 @@ export const HEADER_X_ACROLINX_AUTH = 'X-Acrolinx-Auth';
 export const HEADER_X_ACROLINX_BASE_URL = 'X-Acrolinx-Base-Url';
 export const HEADER_X_ACROLINX_CLIENT_LOCALE = 'X-Acrolinx-Client-Locale';
 export const HEADER_X_ACROLINX_APP_SIGNATURE = 'X-Acrolinx-App';
+export const HEADER_AUTHORIZATION = 'Authorization';

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export interface AcrolinxEndpointProps {
   /*
    * Available in Acrolinx One
    */
-  setTokenAsAuthHeader?: boolean;
+  useTokenAsAuthHeader?: boolean;
 }
 
 export interface ClientInformation {
@@ -586,7 +586,7 @@ export class AcrolinxEndpoint {
       headers[HEADER_X_ACROLINX_CLIENT_LOCALE] = this.props.clientLocale;
     }
     if (accessToken) {
-      this.props.setTokenAsAuthHeader
+      this.props.useTokenAsAuthHeader
         ? (headers[HEADER_AUTHORIZATION] = `Bearer ${accessToken}`)
         : (headers[HEADER_X_ACROLINX_AUTH] = accessToken);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import { AcrolinxError, CheckCanceledByClientError, ErrorType, wrapFetchError } 
 import { AnalysisRequest, ExtractionResult } from './extraction';
 import { PlatformFeatures, PlatformFeaturesResponse } from './features';
 import {
+  HEADER_AUTHORIZATION,
   HEADER_X_ACROLINX_APP_SIGNATURE,
   HEADER_X_ACROLINX_AUTH,
   HEADER_X_ACROLINX_BASE_URL,
@@ -157,6 +158,11 @@ export interface AcrolinxEndpointProps {
    * @ignore
    */
   enableHttpLogging?: boolean;
+
+  /*
+   * Available in Acrolinx One
+   */
+  setTokenAsAuthHeader?: boolean;
 }
 
 export interface ClientInformation {
@@ -580,7 +586,9 @@ export class AcrolinxEndpoint {
       headers[HEADER_X_ACROLINX_CLIENT_LOCALE] = this.props.clientLocale;
     }
     if (accessToken) {
-      headers[HEADER_X_ACROLINX_AUTH] = accessToken;
+      this.props.setTokenAsAuthHeader
+        ? (headers[HEADER_AUTHORIZATION] = `Bearer ${accessToken}`)
+        : (headers[HEADER_X_ACROLINX_AUTH] = accessToken);
     }
     return headers;
   }

--- a/test/test-utils/mock-server.ts
+++ b/test/test-utils/mock-server.ts
@@ -20,7 +20,12 @@ import { MockResponseObject } from 'fetch-mock';
 import * as _ from 'lodash';
 import { SuccessResponse } from '../../src/common-types';
 import { AcrolinxApiError, AcrolinxError, ErrorType } from '../../src/errors';
-import { HEADER_X_ACROLINX_AUTH, HEADER_X_ACROLINX_BASE_URL, HEADER_X_ACROLINX_CLIENT } from '../../src/headers';
+import {
+  HEADER_AUTHORIZATION,
+  HEADER_X_ACROLINX_AUTH,
+  HEADER_X_ACROLINX_BASE_URL,
+  HEADER_X_ACROLINX_CLIENT,
+} from '../../src/headers';
 import { DEVELOPMENT_SIGNATURE } from '../../src/index';
 import { ServerNotificationResponseData } from '../../src/notifications';
 import { AuthorizationType, SigninPollResult, SigninResult, SigninSuccessResult } from '../../src/signin';
@@ -171,11 +176,11 @@ export class AcrolinxServerMock {
     }
 
     if (_.includes(url, '/api/') && !_.includes(url, '/auth/')) {
-      const token = getHeader(opts, HEADER_X_ACROLINX_AUTH);
+      const token = getHeader(opts, HEADER_X_ACROLINX_AUTH) || getHeader(opts, HEADER_AUTHORIZATION);
       if (!token) {
         console.error('Missing Token', token);
         return this.createAcrolinxApiErrorResponse(AUTH_TOKEN_MISSING);
-      } else if (token !== DUMMY_ACCESS_TOKEN) {
+      } else if (!token.includes(DUMMY_ACCESS_TOKEN)) {
         console.error('Invalid Token', token);
         return this.createAcrolinxApiErrorResponse(AUTH_TOKEN_INVALID);
       }

--- a/test/unit/authorization-header.test.ts
+++ b/test/unit/authorization-header.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-present Acrolinx GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DEVELOPMENT_SIGNATURE } from '../../src';
+import { AcrolinxEndpoint } from '../../src/index';
+import { ACROLINX_DEV_SIGNATURE } from '../integration-server/acrolinx-endpoint.test';
+
+function createEndpoint(setTokenAsAuthHeader?: boolean) {
+  return new AcrolinxEndpoint({
+    acrolinxUrl: 'http://host/',
+    enableHttpLogging: true,
+    client: {
+      signature: ACROLINX_DEV_SIGNATURE || DEVELOPMENT_SIGNATURE,
+      version: '1.2.3.666',
+    },
+    setTokenAsAuthHeader,
+  });
+}
+
+describe('Authorization header', () => {
+  describe('set Authorization header props', () => {
+    it('not defined', () => {
+      expect(createEndpoint().props.setTokenAsAuthHeader).toBeUndefined();
+    });
+
+    it('set disabled', () => {
+      expect(createEndpoint(false).props.setTokenAsAuthHeader).toBe(false);
+    });
+
+    it('set enabled', () => {
+      expect(createEndpoint(false).props.setTokenAsAuthHeader).toBe(true);
+    });
+  });
+});

--- a/test/unit/authorization-header.test.ts
+++ b/test/unit/authorization-header.test.ts
@@ -26,22 +26,22 @@ function createEndpoint(setTokenAsAuthHeader?: boolean) {
       signature: ACROLINX_DEV_SIGNATURE || DEVELOPMENT_SIGNATURE,
       version: '1.2.3.666',
     },
-    setTokenAsAuthHeader,
+    useTokenAsAuthHeader: setTokenAsAuthHeader,
   });
 }
 
 describe('Authorization header', () => {
   describe('set Authorization header props', () => {
     it('not defined', () => {
-      expect(createEndpoint().props.setTokenAsAuthHeader).toBeUndefined();
+      expect(createEndpoint().props.useTokenAsAuthHeader).toBeUndefined();
     });
 
     it('set disabled', () => {
-      expect(createEndpoint(false).props.setTokenAsAuthHeader).toBe(false);
+      expect(createEndpoint(false).props.useTokenAsAuthHeader).toBe(false);
     });
 
     it('set enabled', () => {
-      expect(createEndpoint(false).props.setTokenAsAuthHeader).toBe(true);
+      expect(createEndpoint(false).props.useTokenAsAuthHeader).toBe(true);
     });
   });
 });

--- a/test/unit/authorization-header.test.ts
+++ b/test/unit/authorization-header.test.ts
@@ -43,7 +43,7 @@ describe('Authorization header', () => {
   describe('Test API using Auth Header', () => {
     let endpoint: AcrolinxEndpoint;
     beforeEach(() => {
-      const m = mockAcrolinxServer(DUMMY_SERVER_URL);
+      mockAcrolinxServer(DUMMY_SERVER_URL);
       endpoint = createEndpoint(true);
     });
 

--- a/test/unit/authorization-header.test.ts
+++ b/test/unit/authorization-header.test.ts
@@ -41,7 +41,7 @@ describe('Authorization header', () => {
     });
 
     it('set enabled', () => {
-      expect(createEndpoint(false).props.useTokenAsAuthHeader).toBe(true);
+      expect(createEndpoint(true).props.useTokenAsAuthHeader).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Add provision for Athorization Header

If endpoint is set up with `setTokenAsAuthHeader` optional prop.

Token will be used as Authorization header