### PR TITLE
Add guideline id to issues in check result response

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -255,6 +255,7 @@ export interface CommonIssue {
   canAddToDictionary: boolean;
   subIssues?: SubIssue[];
   goalId?: GoalId;
+  guidelineId?: string;
 
   /**
    * Since Acrolinx platform 2021.2

--- a/test/test-utils/dummy-data.ts
+++ b/test/test-utils/dummy-data.ts
@@ -261,6 +261,7 @@ export const DUMMY_CHECK_RESULT: CheckResult = {
       aiRewriteContext: DUMMY_AI_REWRITE_CONTEXT,
       canAddToDictionary: true,
       goalId: 'spelling',
+      guidelineId: 'spelling',
       issueType: IssueType.actionable,
       internalName: 'title_case_chicago',
       displayNameHtml: 'Use Chicago style for the title case?',


### PR DESCRIPTION
In order to get the Guideline id in the issue card (flag) context in our Sidebar.