### PR TITLE
Feat: Add error id generation for AcrolinxError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,6 +16,7 @@
 
 import { DocumentId } from './document-descriptor';
 import { isAIServiceError } from './services/ai-service/ai-service.utils';
+import { errorIdGenerator } from './utils/errorid-generator'
 
 /**
  * See also https://github.com/acrolinx/server-api-spec/blob/master/apiary.apib
@@ -84,6 +85,7 @@ export interface AcrolinxApiError extends AcrolinxErrorProps {
 }
 
 export class AcrolinxError extends Error implements AcrolinxErrorProps {
+  public readonly id: string;
   public readonly type: string;
   public readonly title: string;
   public readonly detail: string;
@@ -97,6 +99,7 @@ export class AcrolinxError extends Error implements AcrolinxErrorProps {
 
   public constructor(props: AcrolinxErrorProps) {
     super(props.title);
+    this.id = errorIdGenerator.generateUniqueErrorIdString();
     this.type = props.type;
     this.status = props.status;
     this.responseHeaders = props.responseHeaders;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,7 +16,7 @@
 
 import { DocumentId } from './document-descriptor';
 import { isAIServiceError } from './services/ai-service/ai-service.utils';
-import { errorIdGenerator } from './utils/errorid-generator'
+import { errorIdGenerator } from './utils/errorid-generator';
 
 /**
  * See also https://github.com/acrolinx/server-api-spec/blob/master/apiary.apib

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -100,7 +100,7 @@ export class AcrolinxError extends Error implements AcrolinxErrorProps {
 
   public constructor(props: AcrolinxErrorProps) {
     super(props.title);
-    this.id = props.id || errorIdGenerator.generateUniqueErrorIdString();
+    this.id = props.id ?? errorIdGenerator.generateUniqueErrorIdString();
     this.type = props.type;
     this.status = props.status;
     this.responseHeaders = props.responseHeaders;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,6 +51,7 @@ export interface AcrolinxErrorProps {
   title: string;
   detail: string;
   type: string;
+  id?: string;
   httpRequest?: HttpRequest;
   status?: number;
   responseHeaders?: Headers;
@@ -99,7 +100,7 @@ export class AcrolinxError extends Error implements AcrolinxErrorProps {
 
   public constructor(props: AcrolinxErrorProps) {
     super(props.title);
-    this.id = errorIdGenerator.generateUniqueErrorIdString();
+    this.id = props.id || errorIdGenerator.generateUniqueErrorIdString();
     this.type = props.type;
     this.status = props.status;
     this.responseHeaders = props.responseHeaders;

--- a/src/utils/errorid-generator.ts
+++ b/src/utils/errorid-generator.ts
@@ -1,5 +1,5 @@
 export class ErrorIdGenerator {
-  private generatedIds: Set<number> = new Set<number>();
+  private readonly generatedIds: Set<number> = new Set<number>();
   private readonly idLength: number = 6;
 
   generateUniqueErrorId(): number {

--- a/src/utils/errorid-generator.ts
+++ b/src/utils/errorid-generator.ts
@@ -1,0 +1,36 @@
+class ErrorIdGenerator {
+  private generatedIds: Set<number> = new Set<number>();
+  private readonly idLength: number = 6;
+
+  generateUniqueErrorId(): number {
+      let newId: number;
+      do {
+          newId = this.generateNonZeroId();
+      } while (this.generatedIds.has(newId));
+
+      this.generatedIds.add(newId);
+      return newId;
+  }
+
+  private generateNonZeroId(): number {
+      let result = '';
+      for (let i = 0; i < this.idLength; i++) {
+          result += Math.floor(Math.random() * 9) + 1; // Generate 1-9
+      }
+      return parseInt(result, 10);
+  }
+
+  generateUniqueErrorIdString(): string {
+      return this.generateUniqueErrorId().toString();
+  }
+
+  reset(): void {
+      this.generatedIds.clear();
+  }
+
+  getGeneratedIds(): number[] {
+      return Array.from(this.generatedIds);
+  }
+}
+
+export const errorIdGenerator = new ErrorIdGenerator();

--- a/src/utils/errorid-generator.ts
+++ b/src/utils/errorid-generator.ts
@@ -1,35 +1,35 @@
-class ErrorIdGenerator {
+export class ErrorIdGenerator {
   private generatedIds: Set<number> = new Set<number>();
   private readonly idLength: number = 6;
 
   generateUniqueErrorId(): number {
-      let newId: number;
-      do {
-          newId = this.generateNonZeroId();
-      } while (this.generatedIds.has(newId));
+    let newId: number;
+    do {
+      newId = this.generateNonZeroId();
+    } while (this.generatedIds.has(newId));
 
-      this.generatedIds.add(newId);
-      return newId;
+    this.generatedIds.add(newId);
+    return newId;
   }
 
   private generateNonZeroId(): number {
-      let result = '';
-      for (let i = 0; i < this.idLength; i++) {
-          result += Math.floor(Math.random() * 9) + 1; // Generate 1-9
-      }
-      return parseInt(result, 10);
+    let result = '';
+    for (let i = 0; i < this.idLength; i++) {
+      result += Math.floor(Math.random() * 9) + 1; // Generate 1-9
+    }
+    return parseInt(result, 10);
   }
 
   generateUniqueErrorIdString(): string {
-      return this.generateUniqueErrorId().toString();
+    return this.generateUniqueErrorId().toString();
   }
 
   reset(): void {
-      this.generatedIds.clear();
+    this.generatedIds.clear();
   }
 
   getGeneratedIds(): number[] {
-      return Array.from(this.generatedIds);
+    return Array.from(this.generatedIds);
   }
 }
 

--- a/test/unit/ai-service.test.ts
+++ b/test/unit/ai-service.test.ts
@@ -131,8 +131,10 @@ describe('AI-service', () => {
         errorId: AIServiceErrorTypes.GENERAL_EXCEPTION,
       });
 
+      await expect(response).rejects.toThrowError(AcrolinxError);
       await expect(response).rejects.toThrowError(
-        new AcrolinxError({
+        expect.objectContaining({
+          id: expect.any(String),
           detail: REQUEST_ERROR_MESSAGE,
           status: 500,
           type: AIServiceErrorTypes.GENERAL_EXCEPTION,
@@ -154,8 +156,10 @@ describe('AI-service', () => {
         errorId: AIServiceErrorTypes.INVALID_USER_INPUT,
       });
 
+      await expect(response).rejects.toThrowError(AcrolinxError);
       await expect(response).rejects.toThrowError(
-        new AcrolinxError({
+        expect.objectContaining({
+          id: expect.any(String),
           detail: FILTERED_RESPONSE_MESSAGE,
           status: 400,
           type: AIServiceErrorTypes.INVALID_USER_INPUT,

--- a/test/unit/errorid-generator.test.ts
+++ b/test/unit/errorid-generator.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest';
+import { ErrorIdGenerator } from '../../src/utils/errorid-generator';
+
+test('ErrorIdGenerator generates unique 6-digit IDs', () => {
+  const generator = new ErrorIdGenerator();
+  const ids: string[] = [];
+
+  for (let i = 0; i < 1000; i++) {
+    const id = generator.generateUniqueErrorIdString();
+    expect(id.length).toBe(6);
+    expect(ids.includes(id)).toBe(false); // Check uniqueness
+    ids.push(id);
+  }
+});
+
+test('ErrorIdGenerator generates IDs without zeros', () => {
+  const generator = new ErrorIdGenerator();
+
+  for (let i = 0; i < 100; i++) {
+    const id = generator.generateUniqueErrorIdString();
+    expect(id).toMatch(/^[1-9]{6}$/); // Regex to check for 6 digits, 1-9
+  }
+});
+
+test('ErrorIdGenerator reset() method clears generated IDs', () => {
+  const generator = new ErrorIdGenerator();
+
+  generator.generateUniqueErrorIdString();
+  generator.generateUniqueErrorIdString();
+  generator.reset();
+
+  const ids = generator.getGeneratedIds();
+  expect(ids.length).toBe(0);
+
+  // Ensure that after reset, the same ID can be generated again.
+  const newId = generator.generateUniqueErrorIdString();
+  expect(newId.length).toBe(6);
+});
+
+test('ErrorIdGenerator getGeneratedIds() returns the correct array', () => {
+  const generator = new ErrorIdGenerator();
+  const id1 = generator.generateUniqueErrorId();
+  const id2 = generator.generateUniqueErrorId();
+  const id3 = generator.generateUniqueErrorId();
+
+  const generatedIds = generator.getGeneratedIds();
+  expect(generatedIds).toEqual([id1, id2, id3]);
+});
+
+test('ErrorIdGenerator generates the correct amount of numbers', () => {
+  const generator = new ErrorIdGenerator();
+  let counter = 0;
+  while (generator.getGeneratedIds().length < 500) {
+    generator.generateUniqueErrorId();
+    counter++;
+  }
+  expect(counter).toBe(500);
+});
+
+test('ErrorIdGenerator generates string ids', () => {
+  const generator = new ErrorIdGenerator();
+  const id = generator.generateUniqueErrorIdString();
+  expect(typeof id).toBe('string');
+});

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import { CheckCanceledByClientError, ErrorType } from '../../src/errors';
+import { AcrolinxError, CheckCanceledByClientError, ErrorType } from '../../src/errors';
 import { AcrolinxEndpoint } from '../../src/index';
 import { mockAcrolinxServer, mockBrokenJsonServer, restoreOriginalFetch } from '../test-utils/mock-server';
 import { DUMMY_ENDPOINT_PROPS, DUMMY_SERVER_URL } from './common';
@@ -30,6 +30,26 @@ describe('errors', () => {
 
   afterEach(() => {
     restoreOriginalFetch();
+  });
+
+  test('error ID string is not empty, null or undefined', async () => {
+    const error = new AcrolinxError({
+      type: ErrorType.HttpErrorStatus,
+      detail: 'Unknown HTTP Error',
+      title: 'Unknown HTTP Error',
+    });
+    expect(error.id).not.toBeNull();
+    expect(error.id).not.toBeUndefined();
+    expect(error.id).toBeTruthy();
+  });
+
+  test('error ID string has 6 digit length', () => {
+    const error = new AcrolinxError({
+      type: ErrorType.HttpErrorStatus,
+      detail: 'Unknown HTTP Error',
+      title: 'Unknown HTTP Error',
+    });
+    expect(error.id.length).toBe(6);
   });
 
   test('should return an failing promise for broken json', async () => {


### PR DESCRIPTION
Move error id generation from Sidebar to the SDK to ensure that error id generation happens whenever a new AcrolinxError object is instantiated. 

This error id then can be shown on error notifications and related error logs can be found containing the error id and the error details.

Relates to DEV-42011