### PR TITLE
DEV-42366 chore: update telemetry interface

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -11,6 +11,7 @@
     "itchy-jars-own",
     "silly-tools-cheat",
     "six-stars-open",
+    "sour-roses-sip",
     "whole-llamas-shave"
   ]
 }

--- a/.changeset/sour-roses-sip.md
+++ b/.changeset/sour-roses-sip.md
@@ -1,0 +1,5 @@
+---
+'@acrolinx/sdk': patch
+---
+
+DEV-42366 chore remove browser engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @acrolinx/sdk
 
+## 2.0.0-beta.7
+
+### Patch Changes
+
+- NONE chore: remove browser engine details
+
 ## 2.0.0-beta.6
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acrolinx/sdk",
-      "version": "2.0.0-beta.6",
+      "version": "2.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/context-zone": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "Acrolinx JavaScript SDK for the Acrolinx API",
   "license": "Apache-2.0",
   "author": "Acrolinx",

--- a/src/telemetry/acrolinxInstrumentation.ts
+++ b/src/telemetry/acrolinxInstrumentation.ts
@@ -7,6 +7,7 @@ import { AcrolinxEndpointProps, IntService } from '../index';
 
 export class AcrolinxInstrumentation {
   private static instance: AcrolinxInstrumentation | null = null;
+  private static instanceConfig: TelemetryConfig | null = null;
   private instruments: Instruments | undefined = undefined;
   private readonly config: TelemetryConfig;
   private readonly intService: IntService;
@@ -18,10 +19,25 @@ export class AcrolinxInstrumentation {
   }
 
   public static getInstance(config: TelemetryConfig): AcrolinxInstrumentation {
-    if (!AcrolinxInstrumentation.instance) {
-      AcrolinxInstrumentation.instance = new AcrolinxInstrumentation(config);
+    if (AcrolinxInstrumentation.instance && 
+        AcrolinxInstrumentation.instanceConfig && 
+        this.configsMatch(AcrolinxInstrumentation.instanceConfig, config)) {
+      return AcrolinxInstrumentation.instance;
     }
+    
+    AcrolinxInstrumentation.instance = new AcrolinxInstrumentation(config);
+    AcrolinxInstrumentation.instanceConfig = { ...config };
     return AcrolinxInstrumentation.instance;
+  }
+  
+  public static resetInstance(): void {
+    AcrolinxInstrumentation.instance = null;
+    AcrolinxInstrumentation.instanceConfig = null;
+  }
+
+  private static configsMatch(config1: TelemetryConfig, config2: TelemetryConfig): boolean {
+    return config1.accessToken === config2.accessToken && 
+           config1.endpointProps === config2.endpointProps;
   }
 
   public async getInstruments(): Promise<Instruments | undefined> {

--- a/src/telemetry/acrolinxInstrumentation.ts
+++ b/src/telemetry/acrolinxInstrumentation.ts
@@ -19,38 +19,39 @@ export class AcrolinxInstrumentation {
   }
 
   public static getInstance(config: TelemetryConfig): AcrolinxInstrumentation {
-    if (AcrolinxInstrumentation.instance && 
-        AcrolinxInstrumentation.instanceConfig && 
-        this.configsMatch(AcrolinxInstrumentation.instanceConfig, config)) {
+    if (
+      AcrolinxInstrumentation.instance &&
+      AcrolinxInstrumentation.instanceConfig &&
+      this.configsMatch(AcrolinxInstrumentation.instanceConfig, config)
+    ) {
       return AcrolinxInstrumentation.instance;
     }
-    
+
     AcrolinxInstrumentation.instance = new AcrolinxInstrumentation(config);
     AcrolinxInstrumentation.instanceConfig = { ...config };
     return AcrolinxInstrumentation.instance;
   }
-  
+
   public static resetInstance(): void {
     AcrolinxInstrumentation.instance = null;
     AcrolinxInstrumentation.instanceConfig = null;
   }
 
   private static configsMatch(config1: TelemetryConfig, config2: TelemetryConfig): boolean {
-    return config1.accessToken === config2.accessToken && 
-           config1.endpointProps === config2.endpointProps;
+    return config1.accessToken === config2.accessToken && config1.endpointProps === config2.endpointProps;
   }
 
   public async getInstruments(): Promise<Instruments | undefined> {
     if (this.instruments) {
       return this.instruments;
     }
-    
+
     if (this.instrumentsPromise) {
       return this.instrumentsPromise;
     }
-    
+
     this.instrumentsPromise = this.createInstruments();
-    
+
     try {
       this.instruments = await this.instrumentsPromise;
       return this.instruments;
@@ -64,12 +65,9 @@ export class AcrolinxInstrumentation {
       if (!(await this.isAllowed(this.config.accessToken))) {
         return undefined;
       }
-      
+
       const meterProvider = setupMetrics(this.config);
-      const defaultCounters = createDefaultMeters(
-        this.config.endpointProps.client.integrationDetails, 
-        meterProvider
-      );
+      const defaultCounters = createDefaultMeters(this.config.endpointProps.client.integrationDetails, meterProvider);
       const logger = setupLogging(this.config);
 
       return {

--- a/src/telemetry/acrolinxInstrumentation.ts
+++ b/src/telemetry/acrolinxInstrumentation.ts
@@ -6,10 +6,11 @@ import { AccessToken } from '../common-types';
 import { AcrolinxEndpointProps, IntService } from '../index';
 
 export class AcrolinxInstrumentation {
-  private static acrolinxInstrumentation: AcrolinxInstrumentation;
-  public instruments: Instruments | undefined = undefined;
+  private static instance: AcrolinxInstrumentation | null = null;
+  private instruments: Instruments | undefined = undefined;
   private readonly config: TelemetryConfig;
   private readonly intService: IntService;
+  private instrumentsPromise: Promise<Instruments | undefined> | null = null;
 
   private constructor(config: TelemetryConfig) {
     this.intService = new IntService(config.endpointProps);
@@ -17,40 +18,67 @@ export class AcrolinxInstrumentation {
   }
 
   public static getInstance(config: TelemetryConfig): AcrolinxInstrumentation {
-    if (!AcrolinxInstrumentation.acrolinxInstrumentation) {
-      AcrolinxInstrumentation.acrolinxInstrumentation = new AcrolinxInstrumentation(config);
-      return AcrolinxInstrumentation.acrolinxInstrumentation;
+    if (!AcrolinxInstrumentation.instance) {
+      AcrolinxInstrumentation.instance = new AcrolinxInstrumentation(config);
     }
-    return AcrolinxInstrumentation.acrolinxInstrumentation;
+    return AcrolinxInstrumentation.instance;
   }
 
   public async getInstruments(): Promise<Instruments | undefined> {
-    if (!(await this.isAllowed(this.config.accessToken))) {
+    if (this.instruments) {
+      return this.instruments;
+    }
+    
+    if (this.instrumentsPromise) {
+      return this.instrumentsPromise;
+    }
+    
+    this.instrumentsPromise = this.createInstruments();
+    
+    try {
+      this.instruments = await this.instrumentsPromise;
+      return this.instruments;
+    } finally {
+      this.instrumentsPromise = null;
+    }
+  }
+
+  private async createInstruments(): Promise<Instruments | undefined> {
+    try {
+      if (!(await this.isAllowed(this.config.accessToken))) {
+        return undefined;
+      }
+      
+      const meterProvider = setupMetrics(this.config);
+      const defaultCounters = createDefaultMeters(
+        this.config.endpointProps.client.integrationDetails, 
+        meterProvider
+      );
+      const logger = setupLogging(this.config);
+
+      return {
+        metrics: {
+          meterProvider,
+          meters: defaultCounters,
+        },
+        logging: {
+          logger,
+        },
+      };
+    } catch (error) {
+      console.error('Failed to create instruments:', error);
       return undefined;
     }
-    const meterProvider = setupMetrics(this.config);
-    const defaultCounters = createDefaultMeters(this.config.endpointProps.client.integrationDetails, meterProvider);
-    const logger = setupLogging(this.config);
-
-    return {
-      metrics: {
-        meterProvider,
-        meters: defaultCounters,
-      },
-      logging: {
-        logger,
-      },
-    };
   }
 
   private async isAllowed(accessToken: AccessToken): Promise<boolean> {
     try {
       const config = await this.intService.getConfig(accessToken);
-      return config?.telemetryEnabled;
-    } catch (e) {
-      console.log(e);
+      return config?.telemetryEnabled ?? false;
+    } catch (error) {
+      console.error('Failed to check if telemetry is allowed:', error);
+      return false;
     }
-    return false;
   }
 }
 
@@ -61,11 +89,11 @@ export const getTelemetryInstruments = async (
   try {
     const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance({
       endpointProps,
-      accessToken: accessToken,
+      accessToken,
     });
     return await acrolinxInstrumentation.getInstruments();
-  } catch (e) {
-    console.log(e);
+  } catch (error) {
+    console.error('Failed to get telemetry instruments:', error);
     return undefined;
   }
 };

--- a/src/telemetry/interfaces/integration.ts
+++ b/src/telemetry/interfaces/integration.ts
@@ -26,13 +26,10 @@ export interface OperatingSystemInfo {
   family: OperatingSystemFamily;
 }
 
-export type Browser =
-  | { name: BrowserNames.chrome; version: string; engine: BrowserEngine.blink }
-  | { name: BrowserNames.firefox; version: string; engine: BrowserEngine.gecko }
-  | { name: BrowserNames.safari; version: string; engine: BrowserEngine.webkit }
-  | { name: BrowserNames.edge; version: string; engine: BrowserEngine.blink }
-  | { name: BrowserNames.javafx; version: string; engine: BrowserEngine.webkit }
-  | { name: BrowserNames.other; version: string; engine: BrowserEngine.other };
+export type Browser = {
+  name: BrowserNames;
+  version: string;
+};
 
 export enum BrowserNames {
   chrome = 'chrome',
@@ -40,13 +37,6 @@ export enum BrowserNames {
   safari = 'safari',
   edge = 'edge',
   javafx = 'javafx',
-  other = 'other',
-}
-
-export enum BrowserEngine {
-  blink = 'blink',
-  gecko = 'gecko',
-  webkit = 'webkit',
   other = 'other',
 }
 

--- a/src/telemetry/metrics/attribute-utils.ts
+++ b/src/telemetry/metrics/attribute-utils.ts
@@ -1,9 +1,8 @@
-import { BrowserEngine, BrowserNames, IntegrationDetails } from '../interfaces/integration';
+import { BrowserNames, IntegrationDetails } from '../interfaces/integration';
 
 export const getCommonMetricAttributes = (integrationDetails: IntegrationDetails) => {
   return {
     'sidebar-version': integrationDetails.systemInfo.sidebarInfo?.version ?? 'unknown',
     'browser-name': integrationDetails.systemInfo.browserInfo?.name ?? BrowserNames.other,
-    'browser-engine': integrationDetails.systemInfo.browserInfo?.engine ?? BrowserEngine.other,
   };
 };

--- a/src/telemetry/metrics/metric-constants.ts
+++ b/src/telemetry/metrics/metric-constants.ts
@@ -1,3 +1,4 @@
 export const metricPrefix = 'integration';
 export const checkRequestMetric = 'check.request';
 export const suggestionMetric = 'suggestion';
+export const EXPORT_INTERVAL_MS = 60000; // 60 seconds

--- a/src/telemetry/metrics/metrics-setup.ts
+++ b/src/telemetry/metrics/metrics-setup.ts
@@ -39,21 +39,23 @@ export const createDefaultMeters = (integrationDetails: IntegrationDetails, mete
   const integrationType = integrationDetails.type;
   const integrationName = integrationDetails.name;
 
+  const prefix = `${metricPrefix}.${integrationType}.${integrationName}`;
+
   return {
     checkRequestCounter: defaultMeter.createCounter(
-      `${metricPrefix}.${integrationType}.${integrationName}.${checkRequestMetric}.counter`,
+      `${prefix}.${checkRequestMetric}.counter`,
     ),
     checkRequestPollingTime: defaultMeter.createHistogram(
-      `${metricPrefix}.${integrationType}.${integrationName}.${checkRequestMetric}.polling-time`,
+      `${prefix}.${checkRequestMetric}.polling-time`,
     ),
     checkRequestSubmitTime: defaultMeter.createHistogram(
-      `${metricPrefix}.${integrationType}.${integrationName}.${checkRequestMetric}.submit-time`,
+      `${prefix}.${checkRequestMetric}.submit-time`,
     ),
     suggestionCounter: defaultMeter.createCounter(
-      `${metricPrefix}.${integrationType}.${integrationName}.${suggestionMetric}.counter`,
+      `${prefix}.${suggestionMetric}.counter`,
     ),
     suggestionResponseTime: defaultMeter.createHistogram(
-      `${metricPrefix}.${integrationType}.${integrationName}.${suggestionMetric}.response-time`,
+      `${prefix}.${suggestionMetric}.response-time`,
     ),
   };
 };

--- a/src/telemetry/metrics/metrics-setup.ts
+++ b/src/telemetry/metrics/metrics-setup.ts
@@ -5,15 +5,16 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { Counter, Histogram } from '@opentelemetry/api';
 import { TelemetryConfig } from '../acrolinxInstrumentation';
 import { IntegrationDetails } from '../interfaces/integration';
-import { checkRequestMetric, metricPrefix, suggestionMetric } from './metric-constants';
+import { checkRequestMetric, EXPORT_INTERVAL_MS, metricPrefix, suggestionMetric } from './metric-constants';
 
-export const setupMetrics = (config: TelemetryConfig) => {
+export const setupMetrics = (config: TelemetryConfig): MeterProvider => {
   const collectorOptions = {
     url: `${config.endpointProps.acrolinxUrl}/otlp/metrics`,
     headers: {
       Authorization: `Bearer ${config.accessToken}`,
     },
   };
+  
   const metricExporter = new OTLPMetricExporter(collectorOptions);
 
   const resource = resourceFromAttributes({
@@ -21,42 +22,38 @@ export const setupMetrics = (config: TelemetryConfig) => {
     [ATTR_SERVICE_VERSION]: config.endpointProps.client.integrationDetails.version,
   });
 
-  const meterProvider = new MeterProvider({
+  return new MeterProvider({
     readers: [
       new PeriodicExportingMetricReader({
         exporter: metricExporter,
-        exportIntervalMillis: 60000, // Every 60 seconds
+        exportIntervalMillis: EXPORT_INTERVAL_MS,
       }),
     ],
     resource,
   });
-
-  return meterProvider;
 };
 
-export const createDefaultMeters = (integrationDetails: IntegrationDetails, meterProvider: MeterProvider): Meters => {
+export const createDefaultMeters = (
+  integrationDetails: IntegrationDetails, 
+  meterProvider: MeterProvider
+): Meters => {
+  const { type: integrationType, name: integrationName } = integrationDetails;
   const defaultMeter = meterProvider.getMeter(metricPrefix);
-  const integrationType = integrationDetails.type;
-  const integrationName = integrationDetails.name;
-
+  
   const prefix = `${metricPrefix}.${integrationType}.${integrationName}`;
+  
+  const checkRequestCounterName = `${prefix}.${checkRequestMetric}.counter`;
+  const checkRequestPollingTimeName = `${prefix}.${checkRequestMetric}.polling-time`;
+  const checkRequestSubmitTimeName = `${prefix}.${checkRequestMetric}.submit-time`;
+  const suggestionCounterName = `${prefix}.${suggestionMetric}.counter`;
+  const suggestionResponseTimeName = `${prefix}.${suggestionMetric}.response-time`;
 
   return {
-    checkRequestCounter: defaultMeter.createCounter(
-      `${prefix}.${checkRequestMetric}.counter`,
-    ),
-    checkRequestPollingTime: defaultMeter.createHistogram(
-      `${prefix}.${checkRequestMetric}.polling-time`,
-    ),
-    checkRequestSubmitTime: defaultMeter.createHistogram(
-      `${prefix}.${checkRequestMetric}.submit-time`,
-    ),
-    suggestionCounter: defaultMeter.createCounter(
-      `${prefix}.${suggestionMetric}.counter`,
-    ),
-    suggestionResponseTime: defaultMeter.createHistogram(
-      `${prefix}.${suggestionMetric}.response-time`,
-    ),
+    checkRequestCounter: defaultMeter.createCounter(checkRequestCounterName),
+    checkRequestPollingTime: defaultMeter.createHistogram(checkRequestPollingTimeName),
+    checkRequestSubmitTime: defaultMeter.createHistogram(checkRequestSubmitTimeName),
+    suggestionCounter: defaultMeter.createCounter(suggestionCounterName),
+    suggestionResponseTime: defaultMeter.createHistogram(suggestionResponseTimeName),
   };
 };
 

--- a/src/telemetry/metrics/metrics-setup.ts
+++ b/src/telemetry/metrics/metrics-setup.ts
@@ -14,7 +14,7 @@ export const setupMetrics = (config: TelemetryConfig): MeterProvider => {
       Authorization: `Bearer ${config.accessToken}`,
     },
   };
-  
+
   const metricExporter = new OTLPMetricExporter(collectorOptions);
 
   const resource = resourceFromAttributes({
@@ -33,15 +33,12 @@ export const setupMetrics = (config: TelemetryConfig): MeterProvider => {
   });
 };
 
-export const createDefaultMeters = (
-  integrationDetails: IntegrationDetails, 
-  meterProvider: MeterProvider
-): Meters => {
+export const createDefaultMeters = (integrationDetails: IntegrationDetails, meterProvider: MeterProvider): Meters => {
   const { type: integrationType, name: integrationName } = integrationDetails;
   const defaultMeter = meterProvider.getMeter(metricPrefix);
-  
+
   const prefix = `${metricPrefix}.${integrationType}.${integrationName}`;
-  
+
   const checkRequestCounterName = `${prefix}.${checkRequestMetric}.counter`;
   const checkRequestPollingTimeName = `${prefix}.${checkRequestMetric}.polling-time`;
   const checkRequestSubmitTimeName = `${prefix}.${checkRequestMetric}.submit-time`;

--- a/test/unit/common.ts
+++ b/test/unit/common.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  IntegrationType,
-  BrowserNames,
-  BrowserEngine,
-  OperatingSystemFamily,
-} from 'src/telemetry/interfaces/integration';
+import { IntegrationType, BrowserNames, OperatingSystemFamily } from 'src/telemetry/interfaces/integration';
 import { AcrolinxEndpointProps, DEVELOPMENT_SIGNATURE } from '../../src';
 
 export const DUMMY_SERVER_URL = 'http://dummy-server';
@@ -35,7 +30,6 @@ export const DUMMY_ENDPOINT_PROPS: AcrolinxEndpointProps = {
       systemInfo: {
         browserInfo: {
           name: BrowserNames.chrome,
-          engine: BrowserEngine.blink,
           version: 'foo',
         },
         sidebarInfo: {

--- a/test/unit/telemetry/telemetry-init.test.ts
+++ b/test/unit/telemetry/telemetry-init.test.ts
@@ -74,14 +74,14 @@ describe('Telemetry initialization', () => {
 
     it('should create a new instance when called with different configuration', () => {
       const instance1 = AcrolinxInstrumentation.getInstance(defaultProps);
-      
+
       const differentProps: TelemetryConfig = {
         ...defaultProps,
         accessToken: 'different-token',
       };
-      
+
       const instance2 = AcrolinxInstrumentation.getInstance(differentProps);
-      
+
       expect(instance1).not.toBe(instance2);
     });
 
@@ -89,7 +89,7 @@ describe('Telemetry initialization', () => {
       const instance1 = AcrolinxInstrumentation.getInstance(defaultProps);
       AcrolinxInstrumentation.resetInstance();
       const instance2 = AcrolinxInstrumentation.getInstance(defaultProps);
-      
+
       expect(instance1).not.toBe(instance2);
     });
   });
@@ -106,7 +106,7 @@ describe('Telemetry initialization', () => {
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
       const instruments = await acrolinxInstrumentation.getInstruments();
-      
+
       expect(instruments?.metrics).toBeDefined();
       expect(instruments?.metrics.meterProvider).toBeDefined();
       expect(instruments?.logging).toBeDefined();
@@ -124,7 +124,7 @@ describe('Telemetry initialization', () => {
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
       const instruments = await acrolinxInstrumentation.getInstruments();
-      
+
       expect(instruments).toBeUndefined();
     });
 
@@ -135,7 +135,7 @@ describe('Telemetry initialization', () => {
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
       const instruments = await acrolinxInstrumentation.getInstruments();
-      
+
       expect(instruments).toBeUndefined();
     });
 
@@ -149,7 +149,7 @@ describe('Telemetry initialization', () => {
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
       const instruments = await acrolinxInstrumentation.getInstruments();
-      
+
       expect(instruments).toBeUndefined();
     });
 
@@ -164,7 +164,7 @@ describe('Telemetry initialization', () => {
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
       const instruments = await acrolinxInstrumentation.getInstruments();
-      
+
       expect(instruments?.metrics).toBeDefined();
       expect(instruments?.metrics.meterProvider).toBeDefined();
       expect(instruments?.logging).toBeDefined();
@@ -183,18 +183,18 @@ describe('Telemetry initialization', () => {
       });
 
       const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
-      
+
       // First call should make an API request
       const instruments1 = await acrolinxInstrumentation.getInstruments();
       expect(instruments1).toBeDefined();
-      
+
       // Clear the mock to verify no additional requests are made
       mocker.clearAll();
-      
+
       // Second call should use cached instruments
       const instruments2 = await acrolinxInstrumentation.getInstruments();
       expect(instruments2).toBeDefined();
-      
+
       // Verify the instruments are the same instance
       expect(instruments1).toBe(instruments2);
     });
@@ -202,7 +202,7 @@ describe('Telemetry initialization', () => {
     it('should handle concurrent calls to getInstruments', async () => {
       // Set up a mock that will be called only once
       let requestCount = 0;
-      
+
       // First, set up the mock with a counter
       server.get('/int-service/api/v1/config', {
         status: 200,
@@ -211,7 +211,7 @@ describe('Telemetry initialization', () => {
           telemetryEnabled: true,
         },
       });
-      
+
       // Then, override the fetch to count requests
       const originalFetch = global.fetch;
       global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -220,22 +220,22 @@ describe('Telemetry initialization', () => {
         }
         return originalFetch(input, init);
       };
-      
+
       try {
         const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
-        
+
         // Make concurrent calls
         const [instruments1, instruments2, instruments3] = await Promise.all([
           acrolinxInstrumentation.getInstruments(),
           acrolinxInstrumentation.getInstruments(),
           acrolinxInstrumentation.getInstruments(),
         ]);
-        
+
         // Verify all calls returned the same instruments
         expect(instruments1).toBeDefined();
         expect(instruments1).toBe(instruments2);
         expect(instruments1).toBe(instruments3);
-        
+
         // Verify only one API request was made
         expect(requestCount).toBe(1);
       } finally {

--- a/test/unit/telemetry/telemetry-init.test.ts
+++ b/test/unit/telemetry/telemetry-init.test.ts
@@ -2,12 +2,7 @@ import { AcrolinxEndpoint } from '../../../src/index';
 import { AcrolinxInstrumentation, TelemetryConfig } from '../../../src/telemetry/acrolinxInstrumentation';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { FetchMocker, MockServer } from 'mentoss';
-import {
-  BrowserEngine,
-  BrowserNames,
-  IntegrationType,
-  OperatingSystemFamily,
-} from '../../../src/telemetry/interfaces/integration';
+import { BrowserNames, IntegrationType, OperatingSystemFamily } from '../../../src/telemetry/interfaces/integration';
 
 describe('Telemtry initialization', () => {
   const acrolinxUrl = 'https://tenant.acrolinx.cloud';
@@ -22,7 +17,6 @@ describe('Telemtry initialization', () => {
         systemInfo: {
           browserInfo: {
             name: BrowserNames.chrome,
-            engine: BrowserEngine.blink,
             version: 'foo',
           },
           sidebarInfo: {

--- a/test/unit/telemetry/telemetry-init.test.ts
+++ b/test/unit/telemetry/telemetry-init.test.ts
@@ -4,7 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { FetchMocker, MockServer } from 'mentoss';
 import { BrowserNames, IntegrationType, OperatingSystemFamily } from '../../../src/telemetry/interfaces/integration';
 
-describe('Telemtry initialization', () => {
+describe('Telemetry initialization', () => {
   const acrolinxUrl = 'https://tenant.acrolinx.cloud';
   const acrolinxEndpoint = new AcrolinxEndpoint({
     acrolinxUrl: acrolinxUrl,
@@ -33,7 +33,7 @@ describe('Telemtry initialization', () => {
       version: '1.2.3.666',
     },
   });
-  const props: TelemetryConfig = {
+  const defaultProps: TelemetryConfig = {
     endpointProps: acrolinxEndpoint.props,
     accessToken: 'random-token',
   };
@@ -49,94 +49,199 @@ describe('Telemtry initialization', () => {
 
   afterEach(() => {
     mocker.clearAll();
+    // Reset the singleton instance after each test to ensure clean state
+    AcrolinxInstrumentation.resetInstance();
   });
 
   afterAll(() => {
     mocker.unmockGlobal();
   });
 
-  it('should create a new instance', () => {
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    expect(acrolinxInstrumentation).toBeDefined();
-  });
-
-  it('should not create multiple instances', () => {
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const acrolinxInstrumentation2 = AcrolinxInstrumentation.getInstance(props);
-    const acrolinxInstrumentation3 = AcrolinxInstrumentation.getInstance(props);
-
-    expect(acrolinxInstrumentation).toBe(acrolinxInstrumentation2);
-    expect(acrolinxInstrumentation).toBe(acrolinxInstrumentation3);
-  });
-
-  it('should return telemtry instrumnents if telemetry in enabled', async () => {
-    server.get('/int-service/api/v1/config', {
-      status: 200,
-      body: {
-        activateGetSuggestionReplacement: true,
-        telemetryEnabled: true,
-      },
+  describe('Singleton pattern', () => {
+    it('should create a new instance when none exists', () => {
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      expect(acrolinxInstrumentation).toBeDefined();
     });
 
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const instruments = await acrolinxInstrumentation.getInstruments();
-    expect(instruments?.metrics).toBeDefined();
-    expect(instruments?.metrics.meterProvider).toBeDefined();
-    expect(instruments?.logging).toBeDefined();
-    expect(instruments?.logging.logger).toBeDefined();
-  });
+    it('should return the same instance when called with the same configuration', () => {
+      const instance1 = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instance2 = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instance3 = AcrolinxInstrumentation.getInstance(defaultProps);
 
-  it('should return undefined if telemetry is disabled', async () => {
-    server.get('/int-service/api/v1/config', {
-      status: 200,
-      body: {
-        activateGetSuggestionReplacement: true,
-        telemetryEnabled: false,
-      },
+      expect(instance1).toBe(instance2);
+      expect(instance1).toBe(instance3);
     });
 
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const instruments = await acrolinxInstrumentation.getInstruments();
-    expect(instruments).toBeUndefined();
-  });
-
-  it('should return undefined if config api returns 500', async () => {
-    server.get('/int-service/api/v1/config', {
-      status: 500,
+    it('should create a new instance when called with different configuration', () => {
+      const instance1 = AcrolinxInstrumentation.getInstance(defaultProps);
+      
+      const differentProps: TelemetryConfig = {
+        ...defaultProps,
+        accessToken: 'different-token',
+      };
+      
+      const instance2 = AcrolinxInstrumentation.getInstance(differentProps);
+      
+      expect(instance1).not.toBe(instance2);
     });
 
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const instruments = await acrolinxInstrumentation.getInstruments();
-    expect(instruments).toBeUndefined();
+    it('should reset the singleton instance when resetInstance is called', () => {
+      const instance1 = AcrolinxInstrumentation.getInstance(defaultProps);
+      AcrolinxInstrumentation.resetInstance();
+      const instance2 = AcrolinxInstrumentation.getInstance(defaultProps);
+      
+      expect(instance1).not.toBe(instance2);
+    });
   });
 
-  it('should return undefined if telemetry config is missing', async () => {
-    server.get('/int-service/api/v1/config', {
-      status: 200,
-      body: {
-        activateGetSuggestionReplacement: true,
-      },
+  describe('getInstruments method', () => {
+    it('should return telemetry instruments when telemetry is enabled', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+          telemetryEnabled: true,
+        },
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instruments = await acrolinxInstrumentation.getInstruments();
+      
+      expect(instruments?.metrics).toBeDefined();
+      expect(instruments?.metrics.meterProvider).toBeDefined();
+      expect(instruments?.logging).toBeDefined();
+      expect(instruments?.logging.logger).toBeDefined();
     });
 
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const instruments = await acrolinxInstrumentation.getInstruments();
-    expect(instruments).toBeUndefined();
+    it('should return undefined when telemetry is disabled', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+          telemetryEnabled: false,
+        },
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instruments = await acrolinxInstrumentation.getInstruments();
+      
+      expect(instruments).toBeUndefined();
+    });
+
+    it('should return undefined when config API returns 500', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 500,
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instruments = await acrolinxInstrumentation.getInstruments();
+      
+      expect(instruments).toBeUndefined();
+    });
+
+    it('should return undefined when telemetry config is missing', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+        },
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instruments = await acrolinxInstrumentation.getInstruments();
+      
+      expect(instruments).toBeUndefined();
+    });
+
+    it('should return telemetry instruments when telemetry config is type string', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+          telemetryEnabled: 'true',
+        },
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      const instruments = await acrolinxInstrumentation.getInstruments();
+      
+      expect(instruments?.metrics).toBeDefined();
+      expect(instruments?.metrics.meterProvider).toBeDefined();
+      expect(instruments?.logging).toBeDefined();
+      expect(instruments?.logging.logger).toBeDefined();
+    });
   });
 
-  it('should return telemtry instrumnents if telemetry config is type string', async () => {
-    server.get('/int-service/api/v1/config', {
-      status: 200,
-      body: {
-        activateGetSuggestionReplacement: true,
-        telemetryEnabled: 'true',
-      },
+  describe('Caching behavior', () => {
+    it('should cache instruments after first successful retrieval', async () => {
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+          telemetryEnabled: true,
+        },
+      });
+
+      const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+      
+      // First call should make an API request
+      const instruments1 = await acrolinxInstrumentation.getInstruments();
+      expect(instruments1).toBeDefined();
+      
+      // Clear the mock to verify no additional requests are made
+      mocker.clearAll();
+      
+      // Second call should use cached instruments
+      const instruments2 = await acrolinxInstrumentation.getInstruments();
+      expect(instruments2).toBeDefined();
+      
+      // Verify the instruments are the same instance
+      expect(instruments1).toBe(instruments2);
     });
 
-    const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(props);
-    const instruments = await acrolinxInstrumentation.getInstruments();
-    expect(instruments?.metrics).toBeDefined();
-    expect(instruments?.metrics.meterProvider).toBeDefined();
-    expect(instruments?.logging).toBeDefined();
-    expect(instruments?.logging.logger).toBeDefined();
+    it('should handle concurrent calls to getInstruments', async () => {
+      // Set up a mock that will be called only once
+      let requestCount = 0;
+      
+      // First, set up the mock with a counter
+      server.get('/int-service/api/v1/config', {
+        status: 200,
+        body: {
+          activateGetSuggestionReplacement: true,
+          telemetryEnabled: true,
+        },
+      });
+      
+      // Then, override the fetch to count requests
+      const originalFetch = global.fetch;
+      global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (typeof input === 'string' && input.includes('/int-service/api/v1/config')) {
+          requestCount++;
+        }
+        return originalFetch(input, init);
+      };
+      
+      try {
+        const acrolinxInstrumentation = AcrolinxInstrumentation.getInstance(defaultProps);
+        
+        // Make concurrent calls
+        const [instruments1, instruments2, instruments3] = await Promise.all([
+          acrolinxInstrumentation.getInstruments(),
+          acrolinxInstrumentation.getInstruments(),
+          acrolinxInstrumentation.getInstruments(),
+        ]);
+        
+        // Verify all calls returned the same instruments
+        expect(instruments1).toBeDefined();
+        expect(instruments1).toBe(instruments2);
+        expect(instruments1).toBe(instruments3);
+        
+        // Verify only one API request was made
+        expect(requestCount).toBe(1);
+      } finally {
+        // Restore the original fetch
+        global.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/test/unit/telemetry/telemtry-attribute.test.ts
+++ b/test/unit/telemetry/telemtry-attribute.test.ts
@@ -1,11 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { getCommonMetricAttributes } from '../../../src/telemetry/metrics/attribute-utils';
-import {
-  BrowserEngine,
-  BrowserNames,
-  IntegrationDetails,
-  IntegrationType,
-} from '../../../src/telemetry/interfaces/integration';
+import { BrowserNames, IntegrationDetails, IntegrationType } from '../../../src/telemetry/interfaces/integration';
 
 describe('getCommonMetricAttributes', () => {
   it('should return correct attributes when all information is provided', () => {
@@ -20,7 +15,6 @@ describe('getCommonMetricAttributes', () => {
         browserInfo: {
           name: BrowserNames.chrome,
           version: '120.0.0',
-          engine: BrowserEngine.blink,
         },
       },
     };
@@ -30,7 +24,6 @@ describe('getCommonMetricAttributes', () => {
     expect(attributes).to.deep.equal({
       'sidebar-version': '2.0.0',
       'browser-name': BrowserNames.chrome,
-      'browser-engine': BrowserEngine.blink,
     });
   });
 
@@ -43,7 +36,6 @@ describe('getCommonMetricAttributes', () => {
         browserInfo: {
           name: BrowserNames.chrome,
           version: '120.0.0',
-          engine: BrowserEngine.blink,
         },
       },
     };
@@ -53,7 +45,6 @@ describe('getCommonMetricAttributes', () => {
     expect(attributes).to.deep.equal({
       'sidebar-version': 'unknown',
       'browser-name': BrowserNames.chrome,
-      'browser-engine': BrowserEngine.blink,
     });
   });
 
@@ -74,19 +65,18 @@ describe('getCommonMetricAttributes', () => {
     expect(attributes).to.deep.equal({
       'sidebar-version': '2.0.0',
       'browser-name': BrowserNames.other,
-      'browser-engine': BrowserEngine.other,
     });
   });
 
   it('should handle different browser types correctly', () => {
     const testCases = [
-      { name: BrowserNames.firefox, engine: BrowserEngine.gecko },
-      { name: BrowserNames.safari, engine: BrowserEngine.webkit },
-      { name: BrowserNames.edge, engine: BrowserEngine.blink },
-      { name: BrowserNames.javafx, engine: BrowserEngine.webkit },
+      { name: BrowserNames.firefox },
+      { name: BrowserNames.safari },
+      { name: BrowserNames.edge },
+      { name: BrowserNames.javafx },
     ] as const;
 
-    testCases.forEach(({ name, engine }) => {
+    testCases.forEach(({ name }) => {
       const integrationDetails: IntegrationDetails = {
         name: 'test-integration',
         version: '1.0.0',
@@ -98,7 +88,6 @@ describe('getCommonMetricAttributes', () => {
           browserInfo: {
             name,
             version: '120.0.0',
-            engine,
           } as any,
         },
       };
@@ -108,7 +97,6 @@ describe('getCommonMetricAttributes', () => {
       expect(attributes).to.deep.equal({
         'sidebar-version': '2.0.0',
         'browser-name': name,
-        'browser-engine': engine,
       });
     });
   });
@@ -126,7 +114,6 @@ describe('getCommonMetricAttributes', () => {
     expect(attributes).to.deep.equal({
       'sidebar-version': 'unknown',
       'browser-name': BrowserNames.other,
-      'browser-engine': BrowserEngine.other,
     });
   });
 });


### PR DESCRIPTION
Remove browser engine. That's too much detail and we don't need it.
Optimize singleton telemetry instance and its tests.