### PR TITLE
Remove metric calls

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -10,6 +10,7 @@
     "honest-lies-cross",
     "itchy-jars-own",
     "silly-tools-cheat",
+    "silver-comics-drum",
     "six-stars-open",
     "sour-roses-sip",
     "whole-llamas-shave"

--- a/.changeset/silver-comics-drum.md
+++ b/.changeset/silver-comics-drum.md
@@ -1,0 +1,5 @@
+---
+'@acrolinx/sdk': patch
+---
+
+DEV-42366 chore: remove metric callsk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @acrolinx/sdk
 
+## 2.0.0-beta.8
+
+### Patch Changes
+
+- DEV-42366 chore: remove metric callsk
+
 ## 2.0.0-beta.7
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acrolinx/sdk",
-      "version": "2.0.0-beta.7",
+      "version": "2.0.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/context-zone": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Acrolinx JavaScript SDK for the Acrolinx API",
   "license": "Apache-2.0",
   "author": "Acrolinx",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,7 @@ import {
   SigninSuccessData,
   SigninSuccessResult,
 } from './signin';
-import { getTelemetryInstruments } from './telemetry/acrolinxInstrumentation';
 import { IntegrationDetails } from './telemetry/interfaces/integration';
-import { getCommonMetricAttributes } from './telemetry/metrics/attribute-utils';
 
 import { User } from './user';
 import {
@@ -311,20 +309,7 @@ export class AcrolinxEndpoint {
   }
 
   public async check(accessToken: AccessToken, req: CheckRequest): Promise<CheckResponse> {
-    const instruments = await getTelemetryInstruments(this.props, accessToken);
-    instruments?.metrics.meters.checkRequestCounter.add(1, {
-      ...getCommonMetricAttributes(this.props.client.integrationDetails),
-    });
-
-    const t0 = performance.now();
-    const response = await post<CheckResponse>('/api/v1/checking/checks', req, {}, this.props, accessToken);
-    const t1 = performance.now();
-
-    instruments?.metrics.meters.suggestionResponseTime.record(t1 - t0, {
-      ...getCommonMetricAttributes(this.props.client.integrationDetails),
-    });
-
-    return response;
+    return await post<CheckResponse>('/api/v1/checking/checks', req, {}, this.props, accessToken);
   }
 
   public async getLiveSuggestions(accessToken: AccessToken, req: LiveSearchRequest): Promise<LiveSearchResponse> {

--- a/src/services/ai-service/ai-service.ts
+++ b/src/services/ai-service/ai-service.ts
@@ -17,8 +17,6 @@
 import { getJsonFromPath, postJsonToPath } from '../../utils/fetch';
 import { AcrolinxEndpointProps, ServiceType } from '../../index';
 import { AiFeatures, ChatCompletionRequest, IsAIEnabledInformation, WriteResponse } from './ai-service.types';
-import { getTelemetryInstruments } from '../../telemetry/acrolinxInstrumentation';
-import { getCommonMetricAttributes } from '../../telemetry/metrics/attribute-utils';
 
 /**
  * Available in Acrolinx One
@@ -63,14 +61,7 @@ export class AIService {
     const { aiRephraseHint: prompt, internalName } = params.issue;
     const { targetUuid, count, previousVersion } = params;
 
-    const instruments = await getTelemetryInstruments(this.endpointProps, accessToken);
-    instruments?.metrics.meters.suggestionCounter.add(1, {
-      ...getCommonMetricAttributes(this.endpointProps.client.integrationDetails),
-    });
-
-    const t0 = performance.now();
-
-    const response = await postJsonToPath<WriteResponse>(
+    return await postJsonToPath<WriteResponse>(
       this.constructFullPath('/ai/chat-completions'),
       {
         prompt,
@@ -83,14 +74,6 @@ export class AIService {
       accessToken,
       { serviceType: ServiceType.ACROLINX_ONE },
     );
-
-    const t1 = performance.now();
-
-    instruments?.metrics.meters.suggestionResponseTime.record(t1 - t0, {
-      ...getCommonMetricAttributes(this.endpointProps.client.integrationDetails),
-    });
-
-    return response;
   }
   private constructFullPath(path: string): string {
     return this.aiServiceBasePath + path;


### PR DESCRIPTION
We have decided to remove metric calls from the SDK and put them where SDK is used. Example: In the Sidebar.
Reason: SDK only returns promises, how to deal with promises when to execute them is call of application using them, adding metrics in SDK disturbs that flow and SDK needs to make decisions on error handling which it cannot do in all scenarios.

Solution:
- Keep the design of SDK intact
- Remove metric calls from check and AI service functions