### PR TITLE
DEV-42366 fix: telemetry endpoint health check

### DIFF
--- a/.changeset/cold-hotels-bow.md
+++ b/.changeset/cold-hotels-bow.md
@@ -1,0 +1,5 @@
+---
+'@acrolinx/sdk': patch
+---
+
+DEV-42366 fix: telemetry endpoint health check

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "@acrolinx/sdk": "2.0.0-beta.3"
   },
   "changesets": [
+    "cold-hotels-bow",
     "curly-bars-start",
     "eager-glasses-battle",
     "every-pillows-share",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @acrolinx/sdk
 
+## 2.0.0-beta.13
+
+### Patch Changes
+
+- DEV-42366 fix: telemetry endpoint health check
+
 ## 2.0.0-beta.12
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acrolinx/sdk",
-      "version": "2.0.0-beta.12",
+      "version": "2.0.0-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/context-zone": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acrolinx/sdk",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "Acrolinx JavaScript SDK for the Acrolinx API",
   "license": "Apache-2.0",
   "author": "Acrolinx",

--- a/src/telemetry/utils/telemetry-util.ts
+++ b/src/telemetry/utils/telemetry-util.ts
@@ -6,6 +6,7 @@ export const checkEndpointReachable = async (url: string, headers: Record<string
         ...headers,
         'Content-Type': 'application/x-protobuf',
       },
+      body: '',
     });
     return response.ok;
   } catch (error) {

--- a/src/telemetry/utils/telemetry-util.ts
+++ b/src/telemetry/utils/telemetry-util.ts
@@ -1,8 +1,11 @@
 export const checkEndpointReachable = async (url: string, headers: Record<string, string>): Promise<boolean> => {
   try {
     const response = await fetch(url, {
-      method: 'HEAD',
-      headers,
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-protobuf',
+      },
     });
     return response.ok;
   } catch (error) {

--- a/test/integration-server/acrolinx-one-endpoint.test.ts
+++ b/test/integration-server/acrolinx-one-endpoint.test.ts
@@ -73,41 +73,6 @@ describe('Acrolinx One E2E Tests', () => {
       expect(aiResult.response).toBeDefined();
       expect(aiResult.intermediateResponse).toBeDefined();
     }, 100000);
-
-    // Run this case manually after running the case for multiple times AI-Service starts giving same response.
-    test('get a chat completion from the ai service & validate previous version too', async () => {
-      const aiService = new AIService(endpoint.props);
-      const aiResult = await aiService.getAIChatCompletion(
-        {
-          issue: {
-            aiRephraseHint:
-              '{"documentId":"ef71d706-b9ef-4b04-95d3-d49c21b2e8e7","aiRephraseHint":[{"role":"system","content":"You are a writing assistant designed to rewrite text as instructed. You write clear, grammatically correct and simple text."},{"role":"system","content":"You will be given an instruction followed by text between triple quotes, like this: ```Text```. Return only rewritten text without the triple quotes."},{"role":"system","content":"Make sure to preserve all markup and hyperscript references."},{"role":"system","content":"Do not provide any copyrighted content. You must not violate any copyrights under any circumstances."},{"role":"system","content":"Use simple language. Split up sentences into shorter ones. Rewrite passive into active voice!"},{"role":"user","content":"Rewrite this sentence to make it less complex. In particular, apply the following changes: Avoid complex coordination. Avoid the passive voice."},{"role":"user","content":"```When you click on Design and select a new Theme, the pictures, charts, and SmartArt graphics will automatically change to match your chosen theme.```"},{"role":"assistant","content":"Sure! Here\'s your new text, with active voice and short, simple sentences:"}]}',
-            internalName: 'clarity_issue',
-          } as unknown as CommonIssue,
-          count: 1,
-          targetUuid: '2755ce18-fa33-4744-a16e-655bd6ce412e',
-        },
-        ACROLINX_API_TOKEN,
-      );
-      expect(aiResult.response).toBeDefined();
-      expect(aiResult.intermediateResponse).toBeDefined();
-      const aiResultSecondTime = await aiService.getAIChatCompletion(
-        {
-          issue: {
-            aiRephraseHint:
-              '{"documentId":"ef71d706-b9ef-4b04-95d3-d49c21b2e8e7","aiRephraseHint":[{"role":"system","content":"You are a writing assistant designed to rewrite text as instructed. You write clear, grammatically correct and simple text."},{"role":"system","content":"You will be given an instruction followed by text between triple quotes, like this: ```Text```. Return only rewritten text without the triple quotes."},{"role":"system","content":"Make sure to preserve all markup and hyperscript references."},{"role":"system","content":"Do not provide any copyrighted content. You must not violate any copyrights under any circumstances."},{"role":"system","content":"Use simple language. Split up sentences into shorter ones. Rewrite passive into active voice!"},{"role":"user","content":"Rewrite this sentence to make it less complex. In particular, apply the following changes: Avoid complex coordination. Avoid the passive voice."},{"role":"user","content":"```When you click on Design and select a new Theme, the pictures, charts, and SmartArt graphics will automatically change to match your chosen theme.```"},{"role":"assistant","content":"Sure! Here\'s your new text, with active voice and short, simple sentences:"}]}',
-            internalName: 'clarity_issue',
-          } as unknown as CommonIssue,
-          count: 2,
-          previousVersion: aiResult.intermediateResponse,
-          targetUuid: '2755ce18-fa33-4744-a16e-655bd6ce412e',
-        },
-        ACROLINX_API_TOKEN,
-      );
-      expect(aiResultSecondTime.response).toBeDefined();
-      expect(aiResultSecondTime.intermediateResponse).toBeDefined();
-      expect(aiResultSecondTime.intermediateResponse).not.equal(aiResultSecondTime.response);
-    }, 100000);
   });
 
   describe('Integrations Service Integration Tests', () => {

--- a/test/unit/telemetry/telemetry-init.test.ts
+++ b/test/unit/telemetry/telemetry-init.test.ts
@@ -261,7 +261,7 @@ describe('Telemetry initialization', () => {
     };
 
     const setupEndpointMock = (endpoint: string, status: number) => {
-      server.head(endpoint, { status });
+      server.post(endpoint, { status });
     };
 
     const verifyMetricsWorking = async (instruments: Instruments | undefined, shouldUseOTLP: boolean) => {


### PR DESCRIPTION
telemetry health check requires to be POST with content-type 'application/x-protobuf' and empty body. It then responds with empty response pointing that API is reachable.

Test:

I have removed the flaky "**get a chat completion from the ai service & validate previous version too**" test. This test doesn't test functionality of SDK. I will move it to compatibility test suite