### PR TITLE
Remove deprecated reviewers Dependabot config option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - /acrolinx/integrationdevs-web
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - /acrolinx/integrationdevs-web
     versioning-strategy: increase


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/